### PR TITLE
Convert swagger path params to koa-router format

### DIFF
--- a/examples/swagger.json
+++ b/examples/swagger.json
@@ -101,7 +101,7 @@
         }
       }
     },
-    "/user/:id": {
+    "/user/{id}": {
       "get": {
         "description": "Return summary of the user",
         "tags": ["user"],

--- a/lib/compiler/swagger/index.js
+++ b/lib/compiler/swagger/index.js
@@ -30,11 +30,25 @@ let Swagger = function (object, options) {
 
   _.extend(this, obj);
 
+  // swagger paths are like {param} but koa-router paths are like :param
+  this.convertPathParameters();
+
   this.setRouteValidationMap();
   this.setSanitizedRoutes();
   this.setControllers();
   return this;
 
+};
+
+Swagger.prototype.convertPathParameters = function () {
+  let paths = {};
+
+  _.each(this.paths, function (controllerConfig, controllerPath) {
+    let path = controllerPath.replace(/\{([^\/]+)\}/g, ':$1');
+    paths[path] = controllerConfig;
+  })
+
+  this.paths = paths;
 };
 
 Swagger.prototype.setControllers = function () {

--- a/tests/swagger.json
+++ b/tests/swagger.json
@@ -101,7 +101,7 @@
         }
       }
     },
-    "/user/:id": {
+    "/user/{id}": {
       "get": {
         "description": "Return summary of the user",
         "tags": ["user"],

--- a/tests/unit_tests.js
+++ b/tests/unit_tests.js
@@ -54,7 +54,8 @@ describe('Unit Tests', function () {
 
 
     describe('.routeSet', function () {
-      let swag          = parser.parse('./tests/swagger.json');
+      let spec          = require('./swagger.json');
+      let swag          = parser.parse(spec);
       let routes        = swag.routeSet();
       let shouldAllHave = function (key, type) {
         _.each(routes, function (val) {
@@ -66,7 +67,18 @@ describe('Unit Tests', function () {
         expect(routes).to.be.an('array');
       });
 
-      describe('.path', function () { it('is string', function () { shouldAllHave('path', 'string'); }); });
+      describe('.path', function () {
+        it('is string', function () { shouldAllHave('path', 'string'); });
+        it('should have converted params', function () {
+          let specPaths = _.keys(spec.paths);
+          expect(specPaths).to.contain('/user/{id}');
+          expect(specPaths).to.not.contain('/user/:id');
+
+          let parsedPaths = _.map(routes, function (route) { return route.path; });
+          expect(parsedPaths).to.contain('/user/:id');
+          expect(parsedPaths).to.not.contain('/user/{id}');
+        });
+      });
       describe('.method', function () { it('is string', function () { shouldAllHave('method', 'string'); }); });
       describe('.controller', function () { it('is string', function () { shouldAllHave('controller', 'string'); }); });
       describe('.details', function () { it('is object', function () { shouldAllHave('details','object'); }); });


### PR DESCRIPTION
I was trying to use fleek-router with swagger-ui but it wouldn't work properly, because they use 2 different formats for path parameters.

http://swagger.io/specification/#pathTemplating says that path parameters should use curly braces.

This change shouldn't break any existing projects using paths like `/user/:id`, it just adds support for the "correct" path format of `/user/{id}`.
